### PR TITLE
CXP-3361: Update the connector to use PutPartnerEvents instead of PutEvents

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
@@ -27,6 +27,8 @@ public class EventBridgeSinkConfig extends AbstractConfig {
   static final String AWS_ENDPOINT_URI_DOC =
       "An optional service endpoint URI used to connect to EventBridge.";
   static final String AWS_EVENTBUS_ARN_CONFIG = "aws.eventbridge.eventbus.arn";
+  static final String AWS_PARTNER_EVENT_SOURCE_NAME_CONFIG =
+      "aws.eventbridge.partner.event.source.name";
   static final String AWS_EVENTBUS_GLOBAL_ENDPOINT_ID_CONFIG =
       "aws.eventbridge.eventbus.global.endpoint.id";
   static final String AWS_RETRIES_CONFIG = "aws.eventbridge.retries.max";
@@ -51,6 +53,8 @@ public class EventBridgeSinkConfig extends AbstractConfig {
       "The unique ID of this connector (used in the event source field to uniquely identify a connector).";
   private static final String AWS_REGION_DOC = "The AWS region of the event bus.";
   private static final String AWS_EVENTBUS_ARN_DOC = "The ARN of the target event bus.";
+  private static final String AWS_PARTNER_EVENT_SOURCE_NAME_DOC =
+      "The name of the partner event source.";
   private static final String AWS_EVENTBUS_ENDPOINT_ID_DOC =
       "An optional global endpoint ID of the target event bus.";
   private static final int AWS_RETRIES_DEFAULT = 2;
@@ -101,6 +105,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
   public final String connectorId;
   public final String region;
   public final String eventBusArn;
+  public final String partnerEventSourceName;
   public final String endpointID;
   public final String endpointURI;
   public final String awsCredentialsProviderClass;
@@ -123,6 +128,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
     this.connectorId = getString(AWS_CONNECTOR_ID_CONFIG);
     this.region = getString(AWS_REGION_CONFIG);
     this.eventBusArn = getString(AWS_EVENTBUS_ARN_CONFIG);
+    this.partnerEventSourceName = getString(AWS_PARTNER_EVENT_SOURCE_NAME_CONFIG);
     this.endpointID = getString(AWS_EVENTBUS_GLOBAL_ENDPOINT_ID_CONFIG);
     this.endpointURI = getString(AWS_ENDPOINT_URI_CONFIG);
     this.awsCredentialsProviderClass = getString(AWS_CREDENTIAL_PROVIDER_CLASS);
@@ -148,12 +154,13 @@ public class EventBridgeSinkConfig extends AbstractConfig {
       detailType = detailTypes.get(0);
     }
     log.info(
-        "EventBridge properties: connectorId={} eventBusArn={} eventBusRegion={} eventBusEndpointURI={} "
+        "EventBridge properties: connectorId={} eventBusArn={} partnerEventSourceName={} eventBusRegion={} eventBusEndpointURI={} "
             + "eventBusMaxRetries={} eventBusRetriesDelay={} eventBusResources={} "
             + "eventBusEndpointID={} roleArn={} roleSessionName={} roleExternalID={} "
             + "offloadingDefaultS3Bucket={} offloadingDefaultS3Prefix={} offloadingDefaultFieldRef={} detailTypeMapperClass={} timeMapperClass={}",
         connectorId,
         eventBusArn,
+        partnerEventSourceName,
         region,
         endpointURI,
         maxRetries,
@@ -179,7 +186,13 @@ public class EventBridgeSinkConfig extends AbstractConfig {
   private static void addParams(final ConfigDef configDef) {
     configDef.define(AWS_CONNECTOR_ID_CONFIG, Type.STRING, Importance.HIGH, AWS_CONNECTOR_ID_DOC);
     configDef.define(AWS_REGION_CONFIG, Type.STRING, Importance.HIGH, AWS_REGION_DOC);
-    configDef.define(AWS_EVENTBUS_ARN_CONFIG, Type.STRING, Importance.HIGH, AWS_EVENTBUS_ARN_DOC);
+    configDef.define(AWS_EVENTBUS_ARN_CONFIG, Type.STRING, "", Importance.HIGH, AWS_EVENTBUS_ARN_DOC);
+    configDef.define(
+        AWS_PARTNER_EVENT_SOURCE_NAME_CONFIG,
+        Type.STRING,
+        "",
+        Importance.HIGH,
+        AWS_PARTNER_EVENT_SOURCE_NAME_DOC);
     configDef.define(
         AWS_ENDPOINT_URI_CONFIG, Type.STRING, "", Importance.MEDIUM, AWS_ENDPOINT_URI_DOC);
     configDef.define(

--- a/src/main/java/software/amazon/event/kafkaconnector/batch/EventBridgeBatchingStrategy.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/batch/EventBridgeBatchingStrategy.java
@@ -6,12 +6,12 @@ package software.amazon.event.kafkaconnector.batch;
 
 import java.util.List;
 import java.util.stream.Stream;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 @FunctionalInterface
 public interface EventBridgeBatchingStrategy {
 
-  Stream<List<MappedSinkRecord<PutEventsRequestEntry>>> apply(
-      Stream<MappedSinkRecord<PutEventsRequestEntry>> records);
+  Stream<List<MappedSinkRecord<PutPartnerEventsRequestEntry>>> apply(
+      Stream<MappedSinkRecord<PutPartnerEventsRequestEntry>> records);
 }

--- a/src/main/java/software/amazon/event/kafkaconnector/batch/SingletonEventBridgeBatching.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/batch/SingletonEventBridgeBatching.java
@@ -7,13 +7,13 @@ package software.amazon.event.kafkaconnector.batch;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 public class SingletonEventBridgeBatching implements EventBridgeBatchingStrategy {
   @Override
-  public Stream<List<MappedSinkRecord<PutEventsRequestEntry>>> apply(
-      Stream<MappedSinkRecord<PutEventsRequestEntry>> records) {
+  public Stream<List<MappedSinkRecord<PutPartnerEventsRequestEntry>>> apply(
+      Stream<MappedSinkRecord<PutPartnerEventsRequestEntry>> records) {
     return records.map(Collections::singletonList);
   }
 }

--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
@@ -12,7 +12,7 @@ import static software.amazon.event.kafkaconnector.EventBridgeResult.success;
 
 import java.util.List;
 import org.apache.kafka.connect.sink.SinkRecord;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.EventBridgeResult;
 import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;
 
@@ -48,13 +48,12 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
     return new EventBridgeMappingResult(successfulMappedRecords, failedMappedRecords);
   }
 
-  private EventBridgeResult<PutEventsRequestEntry> createPutEventsEntry(SinkRecord record) {
+  private EventBridgeResult<PutPartnerEventsRequestEntry> createPutEventsEntry(SinkRecord record) {
     try {
       return success(
           record,
-          PutEventsRequestEntry.builder()
-              .eventBusName(config.eventBusArn)
-              .source(sourcePrefix + config.connectorId)
+          PutPartnerEventsRequestEntry.builder()
+              .source(config.partnerEventSourceName)
               .detailType(detailTypeMapper.getDetailType(record))
               .resources(config.resources)
               .detail(jsonMapper.createJsonPayload(record))

--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultTimeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultTimeMapper.java
@@ -12,7 +12,7 @@ public class DefaultTimeMapper implements TimeMapper {
   @Override
   public Instant getTime(SinkRecord sinkRecord) {
     // As described in AWS documentation
-    // https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEventsRequestEntry.html
+    // https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPartnerEventsRequestEntry.html
     // If no timestamp is provided, the timestamp of the PutEvents call is used.
     return null;
   }

--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/EventBridgeMappingResult.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/EventBridgeMappingResult.java
@@ -7,17 +7,17 @@ package software.amazon.event.kafkaconnector.mapping;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.EventBridgeResult;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 public class EventBridgeMappingResult {
 
-  public List<MappedSinkRecord<PutEventsRequestEntry>> success;
+  public List<MappedSinkRecord<PutPartnerEventsRequestEntry>> success;
   public List<MappedSinkRecord<EventBridgeResult.Error>> errors;
 
   public EventBridgeMappingResult(
-      List<MappedSinkRecord<PutEventsRequestEntry>> success,
+      List<MappedSinkRecord<PutPartnerEventsRequestEntry>> success,
       List<MappedSinkRecord<EventBridgeResult.Error>> errors) {
     this.success = success;
     this.errors = errors;

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/EventBridgeEventDetailValueOffloadingStrategy.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/EventBridgeEventDetailValueOffloadingStrategy.java
@@ -5,7 +5,7 @@
 package software.amazon.event.kafkaconnector.offloading;
 
 import java.util.List;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.mapping.EventBridgeMappingResult;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
@@ -13,5 +13,5 @@ import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 public interface EventBridgeEventDetailValueOffloadingStrategy {
 
   EventBridgeMappingResult apply(
-      List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries);
+      List<MappedSinkRecord<PutPartnerEventsRequestEntry>> putEventsRequestEntries);
 }

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloading.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloading.java
@@ -7,7 +7,7 @@ package software.amazon.event.kafkaconnector.offloading;
 import static java.util.Collections.emptyList;
 
 import java.util.List;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.mapping.EventBridgeMappingResult;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
@@ -16,7 +16,7 @@ public class NoOpEventBridgeEventDetailValueOffloading
 
   @Override
   public EventBridgeMappingResult apply(
-      List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries) {
+      List<MappedSinkRecord<PutPartnerEventsRequestEntry>> putEventsRequestEntries) {
     return new EventBridgeMappingResult(putEventsRequestEntries, emptyList());
   }
 }

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloading.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloading.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -132,7 +132,7 @@ public class S3EventBridgeEventDetailValueOffloading
           format("JSON Path must be definite but '%s' is not.", value));
     }
     // rewrite $.detail -> $,
-    // because PutEventsRequestEntry#detail is the sub document of $.detail
+    // because PutPartnerEventsRequestEntry#detail is the sub document of $.detail
     return JsonPath.compile("$" + jsonPath.getPath().substring("$['detail']".length()));
   }
 
@@ -142,7 +142,7 @@ public class S3EventBridgeEventDetailValueOffloading
 
   @Override
   public EventBridgeMappingResult apply(
-      final List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries) {
+      final List<MappedSinkRecord<PutPartnerEventsRequestEntry>> putEventsRequestEntries) {
 
     var result =
         putEventsRequestEntries.stream()
@@ -155,8 +155,8 @@ public class S3EventBridgeEventDetailValueOffloading
     return new EventBridgeMappingResult(success, errors);
   }
 
-  private EventBridgeResult<PutEventsRequestEntry> apply(
-      final MappedSinkRecord<PutEventsRequestEntry> item) {
+  private EventBridgeResult<PutPartnerEventsRequestEntry> apply(
+      final MappedSinkRecord<PutPartnerEventsRequestEntry> item) {
 
     var sinkRecord = item.getSinkRecord();
     var putEventsRequestEntry = item.getValue();

--- a/src/main/java/software/amazon/event/kafkaconnector/util/EventBridgeEventId.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/util/EventBridgeEventId.java
@@ -4,7 +4,7 @@
  */
 package software.amazon.event.kafkaconnector.util;
 
-import software.amazon.awssdk.services.eventbridge.model.PutEventsResultEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsResultEntry;
 
 public class EventBridgeEventId {
 
@@ -14,7 +14,7 @@ public class EventBridgeEventId {
     this.value = value;
   }
 
-  public static EventBridgeEventId of(final PutEventsResultEntry entry) {
+  public static EventBridgeEventId of(final PutPartnerEventsResultEntry entry) {
     return new EventBridgeEventId(entry.eventId());
   }
 

--- a/src/test/java/software/amazon/event/kafkaconnector/TestUtils.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/TestUtils.java
@@ -23,7 +23,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsResultEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsResultEntry;
 
 public abstract class TestUtils {
 
@@ -54,14 +54,17 @@ public abstract class TestUtils {
     }
   }
 
-  public abstract static class OfPutEventsResultEntry {
+  public abstract static class OfPutPartnerEventsResultEntry {
 
-    private OfPutEventsResultEntry() {}
+    private OfPutPartnerEventsResultEntry() {}
 
-    public static List<PutEventsResultEntry> withIdsIn(IntStream range) {
+    public static List<PutPartnerEventsResultEntry> withIdsIn(IntStream range) {
       return range
           .mapToObj(
-              id -> PutEventsResultEntry.builder().eventId(String.format("eventId:%d", id)).build())
+              id ->
+                  PutPartnerEventsResultEntry.builder()
+                      .eventId(String.format("eventId:%d", id))
+                      .build())
           .collect(toList());
     }
   }

--- a/src/test/java/software/amazon/event/kafkaconnector/batch/SingletonEventBridgeBatchingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/batch/SingletonEventBridgeBatchingTest.java
@@ -17,14 +17,14 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 public class SingletonEventBridgeBatchingTest {
 
   private static final EventBridgeBatchingStrategy strategy = new SingletonEventBridgeBatching();
 
-  private static final Function<List<MappedSinkRecord<PutEventsRequestEntry>>, List<String>>
+  private static final Function<List<MappedSinkRecord<PutPartnerEventsRequestEntry>>, List<String>>
       sinkRecordId =
           xs ->
               xs.stream()
@@ -46,9 +46,9 @@ public class SingletonEventBridgeBatchingTest {
     assertThat(strategy.apply(input)).extracting(sinkRecordId).hasSameElementsAs(expected);
   }
 
-  private MappedSinkRecord<PutEventsRequestEntry> createMappedSinkRecord(String id) {
+  private MappedSinkRecord<PutPartnerEventsRequestEntry> createMappedSinkRecord(String id) {
     return new MappedSinkRecord<>(
-        createTestRecordWithId(id), PutEventsRequestEntry.builder().build());
+        createTestRecordWithId(id), PutPartnerEventsRequestEntry.builder().build());
   }
 
   private SinkRecord createTestRecordWithId(String id) {

--- a/src/test/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloadingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloadingTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 class NoOpEventBridgeEventDetailValueOffloadingTest {
@@ -22,7 +22,7 @@ class NoOpEventBridgeEventDetailValueOffloadingTest {
       new NoOpEventBridgeEventDetailValueOffloading();
 
   @Test
-  @DisplayName("result of successful offloaded PutEventsRequestEntry should be empty")
+  @DisplayName("result of successful offloaded PutPartnerEventsRequestEntry should be empty")
   public void keepEmpty() {
     var actual = strategy.apply(emptyList());
 
@@ -31,12 +31,12 @@ class NoOpEventBridgeEventDetailValueOffloadingTest {
   }
 
   @ParameterizedTest(name = "with size {0}")
-  @DisplayName("result of successful offloaded PutEventsRequestEntry should be unmodified")
+  @DisplayName("result of successful offloaded PutPartnerEventsRequestEntry should be unmodified")
   @ValueSource(longs = {1, 10, 100})
   public void keepSame(long size) {
 
     var items =
-        Stream.generate(() -> new MappedSinkRecord<PutEventsRequestEntry>(null, null))
+        Stream.generate(() -> new MappedSinkRecord<PutPartnerEventsRequestEntry>(null, null))
             .limit(size)
             .collect(toList());
 

--- a/src/test/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloadingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloadingTest.java
@@ -69,7 +69,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutPartnerEventsRequestEntry;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -766,7 +766,7 @@ class S3EventBridgeEventDetailValueOffloadingTest {
     };
   }
 
-  private List<MappedSinkRecord<PutEventsRequestEntry>> withDefaultEventBridgeMapperMap(
+  private List<MappedSinkRecord<PutPartnerEventsRequestEntry>> withDefaultEventBridgeMapperMap(
       final EventBridgeSinkConfig config, final SinkRecord... values) {
     var mapper = new DefaultEventBridgeMapper(config);
     var result = mapper.map(List.of(values));


### PR DESCRIPTION
This changes the PutEvents API call to use PutPartnerEvents and allows the connector to act as a PartnerEventSource given the `aws.eventbridge.partner.event.source.name`. 